### PR TITLE
Solve the issue #15

### DIFF
--- a/2_replace.pl
+++ b/2_replace.pl
@@ -78,7 +78,9 @@ sub IChange
 	my $stcI_extension="";
 	my $stcI_filepostfix="";
 	my $stcI_fileprefix="";
-	my $stcI_filebody="";
+	my $stcI_filebody="YES";
+	my $stcI_file_lower = "NO";
+    my $stcI_all_lower = "NO";
 	my $stcI_lines = "";
 	my @stcI_lines;
 	my $stcfilename="";
@@ -131,6 +133,10 @@ $tttime = $Hour * 3600 + $Minute * 60 + $Second;
         }
 		$stcfilename =~ s/KEY/$temp/g;
 		$stcfilename =~ s/VALUE/$$stcI_for{$temp}/g;
+        print "final file name 1 : $stcfilename";
+		$stcfilename = replace_var_with_value($stcfilename);
+        print "final file name 2 : $stcfilename";
+		$ttt = replace_var_with_value($ttt);
         if($stcI_all_lower eq "YES"){ $stcfilename = lc($stcfilename); }
         my $stcNoDirectoryName = $stcfilename;
         $stcNoDirectoryName =~ s/\//_/g;

--- a/msg
+++ b/msg
@@ -1,7 +1,15 @@
-Support a single variable. $VARIABLE{?}
+Solve the issue #15
 
-- Issue : I wanna get single variable not hash. #12
-	- modified:   1_example.xlsx
-        - example  [VARIABLE]Name
-	- modified:   1_excel.pl
-        - process [VARIABLE]tag
+- use +<+...+>+ (replacement syntax) (ex. KEY=Wifi)
+     - stcI_FILEPREFIX:+<+lc(KEY)+>+I => wifiI
+     - stcI_FILEPOSTFIX:+<+uc(KEY)+>+man => WIFIman
+     - SetI : $MODULENAME = +<+uc(KEY)+>+ => $MODULENAME = WIFI
+- example (KEY = Wifi)
+    - IXXXManagerService.h.stcI
+        - stcI_FILEPREFIX : +<+uc(KEY)+>+ManagerService/include/I
+        - stcI_FILEPOSTFIX : ManagerService
+        - stcI_EXTENSION : h
+        - SetI : $MODULENAME = +<+uc(KEY)+>+
+    - OUTPUT/tmp/WifiManagerService_include_IWifiManagerService.h.stc
+        - FileName : WIFIManagerService/include/IWifiManagerService.h
+        - Set : $MODULENAME = WIFI

--- a/test/DIAG/IXXXManagerService.h.stcI
+++ b/test/DIAG/IXXXManagerService.h.stcI
@@ -1,9 +1,9 @@
 stcI_HASH : Module_Name
-stcI_FILEPREFIX : KEYManagerService/include/I
+stcI_FILEPREFIX : +<+uc(KEY)+>+ManagerService/include/I
 stcI_FILEPOSTFIX : ManagerService
 stcI_EXTENSION : h
 Set : $iterate_comments = OFF
-SetI : $MODULENAME = KEY
+SetI : $MODULENAME = +<+uc(KEY)+>+
 // FileName - I+<+ucfirst($MODULENAME)+>+ManagerService.h
 /**
  * \file    I+<+ucfirst($MODULENAME)+>+ManagerService.h


### PR DESCRIPTION
Solve the issue #15 

- use +<+...+>+ (replacement syntax) (ex. KEY=Wifi)
     - stcI_FILEPREFIX:+<+lc(KEY)+>+I => wifiI
     - stcI_FILEPOSTFIX:+<+uc(KEY)+>+man => WIFIman
     - SetI : $MODULENAME = +<+uc(KEY)+>+ => $MODULENAME = WIFI
- example (KEY = Wifi)
    - IXXXManagerService.h.stcI
        - stcI_FILEPREFIX : +<+uc(KEY)+>+ManagerService/include/I
        - stcI_FILEPOSTFIX : ManagerService
        - stcI_EXTENSION : h
        - SetI : $MODULENAME = +<+uc(KEY)+>+
    - OUTPUT/tmp/WifiManagerService_include_IWifiManagerService.h.stc
        - FileName : WIFIManagerService/include/IWifiManagerService.h
        - Set : $MODULENAME = WIFI