### PR TITLE
add in($a,$b) sub-function : is $b in $a?

### DIFF
--- a/2_replace.pl
+++ b/2_replace.pl
@@ -75,6 +75,16 @@ sub substitute {
     return $my_s;
 }
 
+sub in {
+    my $my_a = shift @_;
+    my $my_b = shift @_;
+    if($my_a = /$my_b/){
+        return $my_b;
+    } else {
+        return "";
+    }
+}
+
 sub countKey {
     my $my_s = shift @_;
     my $my_count = 0;

--- a/msg
+++ b/msg
@@ -1,4 +1,8 @@
-add 1_csv.pl to run without XLSX perl package
+add in($a,$b) sub-function : is $b in $a?
+
+200424--------------
+- add in sub-function
+- IFEQUAL("+<+in($modulename,tidl)+>+","")
 
 200401--------------
 you can run with  csv file instead of xlsx file.


### PR DESCRIPTION
200424--------------
- add in sub-function
- IFEQUAL("+<+in($modulename,tidl)+>+","")

200401--------------
you can run with  csv file instead of xlsx file.
First of all , you convert the file into csv file when you have error of perl package for excel.
if you use MAC OSX , your csv file will have as one line with ^M. so you can replace ^M with \r\n

--------------
support sldd & %+<+$API+>+ and restore $g_y policy (plus)

v1.0.4
- support sldd
- support ```ITERATE %+<+$API+>+ ``` syntax
    - add ```$iterate_var_name = replace_var_with_value($iterate_var_name);```
- restore $g_y policy (plus)
    - replace_var_with_value does not break becasue break contents to improve speed  is impossible to keep the order when we count with plus().