### PR TITLE
2020.07.26 [-b master] v1.0.4 I think this is final update to support…

### DIFF
--- a/2_replace.pl
+++ b/2_replace.pl
@@ -8,7 +8,6 @@ use Cwd  qw(abs_path);
 use lib dirname(dirname abs_path $0) . '/perllib';
 
 
-
 sub __SUB__ { return  (caller 2)[3] . "|" . (caller 2)[2] . "-" . (caller 1)[3] . "|" . (caller 1)[2] . "-" . (caller 0)[2] . ": " }
 
 sub versionMismatch {
@@ -38,6 +37,8 @@ sub help
 	printf("\t\t  run NO performance mode\n");
 	printf("\t--nolog");
 	printf("\t\t  print log into /dev/null\n");
+	printf("\t--yours=[module file name]\n");
+	printf("\t\t  default is null (not use it)\n");
 	printf("\t--help\n");
 }
 
@@ -1413,11 +1414,13 @@ our $cga_rdl_version_input_file   = "";
 our $cgaRdlVersionMajor;
 our $cgaRdlVersionMinor;
 our $cgaRdlVersionDev;
+our $yours_module = "";
 
 GetOptions (
 		"inputstci=s"   => \$stcfilename,      # string
 		"outputdb=s"   => \$filename,      # string
 		"cga_rdl_version_input=s"   => \$cga_rdl_version_input_file,      # string
+		"yours=s"   => \$yours_module,      # string
         "debug" => sub { $optionDebug = 1 },   # flag
         "debugdetail" => sub { $optionDebug = 1;  $optionDebugDetail = 1;  },   # flag
         "original" => sub { $optionPerformance = 0 },   # flag
@@ -1445,6 +1448,16 @@ if($cga_rdl_version_input_file ne ""){
         $cga_rdl_version_input_file = "";
     }
 }
+
+if($yours_module ne ""){
+    if(-e "./$yours_module"){
+        print STDERR "Exist $yours_module in your directory!\n";
+        require "./$yours_module"
+    } else {
+        print STDERR "Not exist $yours_module in your directory!\n";
+    }
+}
+
 
 
 mkdir "OUTPUT";

--- a/msg.md
+++ b/msg.md
@@ -1,3 +1,43 @@
+2020.07.26 [-b master] v1.0.4 I think this is final update to support sub functions for each module (ex. TIDL) 
+
+- refer to : https://stackoverflow.com/questions/1712016/how-do-i-include-functions-from-another-file-in-my-perl-script
+```
+$ cat m1.pl 
+use strict;
+sub x { warn "aard"; }
+1;
+
+$ cat m2.pl 
+use strict;
+require "m1.pl";
+x();
+
+$ perl m2.pl 
+aard at m1.pl line 2.
+```
+
+- we do not chnange anymore to support special function for TIDL
+    - if TIDL has yours.pl ,  you add --yours=yours.pl after 2_replace.pl
+- add option : --yours
+perlscript=2_replace.pl
+Help :
+	--inputstci=[stcI or stc file]
+		  default input stc or stcI file name : 
+	--outputdb=[output file]
+		  default output DB file name : 
+	--cga_rdl_version_input=[version file name]
+		  default input version file name : 
+		  if null , we ignore the version between excel version input file and [VARIABLE]Excel_Version  in excel file ()
+	--debug		  debug mode : ITERATE  IFEQUAL IFNOTEQUAL
+	--debugdetail		  --debug + ITERATE detail 
+		  debug mode : ITERATE  IFEQUAL IFNOTEQUAL  ITERATE detail 
+	--original		  run NO performance mode
+	--nolog		  print log into /dev/null
+	--yours=[module file name]
+		  default is null (not use it)
+	--help
+
+-------------------------------------------
 2020.07.14 [-b master] v1.0.4 solve #45 : -o StrictHostKeyChecking=no passes the qeustion yes/no when we connect the host at first.
 
 - 1_csv.pl  1_excel.pl


### PR DESCRIPTION
… sub functions for each module (ex. TIDL)

- refer to : https://stackoverflow.com/questions/1712016/how-do-i-include-functions-from-another-file-in-my-perl-script
```
$ cat m1.pl
use strict;
sub x { warn "aard"; }
1;

$ cat m2.pl
use strict;
require "m1.pl";
x();

$ perl m2.pl
aard at m1.pl line 2.
```

- we do not chnange anymore to support special function for TIDL
    - if TIDL has yours.pl ,  you add --yours=yours.pl after 2_replace.pl
- add option : --yours
perlscript=2_replace.pl
Help :
	--inputstci=[stcI or stc file]
		  default input stc or stcI file name :
	--outputdb=[output file]
		  default output DB file name :
	--cga_rdl_version_input=[version file name]
		  default input version file name :
		  if null , we ignore the version between excel version input file and [VARIABLE]Excel_Version  in excel file ()
	--debug		  debug mode : ITERATE  IFEQUAL IFNOTEQUAL
	--debugdetail		  --debug + ITERATE detail
		  debug mode : ITERATE  IFEQUAL IFNOTEQUAL  ITERATE detail
	--original		  run NO performance mode
	--nolog		  print log into /dev/null
	--yours=[module file name]
		  default is null (not use it)
	--help